### PR TITLE
[ADD] add 'OCA/repository' as category when sorting addons coming from OCA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+name: Test
+
+on:
+  push:
+    branches: ["main", "master"]
+    tags: ["*"]
+  pull_request:
+
+jobs:
+  test:
+    name: "Python ${{ matrix.python-version }}"
+    runs-on: ${{ matrix.machine }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - python-version: "3.10"
+            machine: ubuntu-22.04
+          - python-version: "3.11"
+            machine: ubuntu-22.04
+          - python-version: "3.12"
+            machine: ubuntu-24.04
+          - python-version: "3.13"
+            machine: ubuntu-24.04
+          - python-version: "3.14"
+            machine: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prerelease: true
+
+      - name: Install hatch
+        run: pip install hatch
+
+      - name: Run tests
+        run: hatch run test
+
+      - name: Check test coverage
+        run: hatch run test-cov-xml
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12' && github.ref == 'refs/heads/main'
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ Options:
   --odoo-version TEXT           Project's Odoo version (e.g. 16.0)  [required]
   --project-name TEXT           Name of the project, will be the name of
                                 category of local addons (default: Local)
-  --oca-category                Add category for third party addons coming from OCA
+  --oca-category [basic|repository]
+                                Add category for third party addons coming
+                                from OCA. If 'basic': category is set to
+                                'OCA'. If 'repository': category is set as
+                                'OCA/<repository_name>', if the repository
+                                can not be identified, it falls into the
+                                default 'OCA' category.
   --reset-cache                 Purge cache used to identify OCA addons
   --help                        Show this message and exit.
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # odoo-sort-manifest-depends
 
+[![Test Status](https://github.com/acsone/odoo-sort-manifest-depends/actions/workflows/test.yml/badge.svg)](https://github.com/acsone/odoo-sort-manifest-depends/actions/workflows/test.yml)
+[![Code Coverage](https://img.shields.io/codecov/c/github/acsone/odoo-sort-manifest-depends)](https://codecov.io/gh/acsone/odoo-sort-manifest-depends)
+
 ## Table of Contents
 
 - [Help](#help)
@@ -38,6 +41,28 @@ This project is distributed on PyPI. The recommended way to run it is with
 [pipx](https://github.com/pypa/pipx), with a command like this:
 
 `pipx run odoo-sort-manifest-depends --local-addons-dir=odoo/addons --odoo-version=16.0`
+
+## Running tests
+
+### Local development with Hatch
+
+```bash
+# Install hatch if you don't have it
+pip install hatch
+
+# Run tests
+hatch run test
+
+# Run tests with coverage
+hatch run test-cov
+```
+
+### Using pytest directly
+
+```bash
+pip install -r requirements-test.txt
+pytest tests/ -v
+```
 
 ## Using with pre-commit
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
   "diskcache",
   "requests",
   "platformdirs",
+  "packaging",
+  "mousebender",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,11 +95,12 @@ known-first-party = ["odoo_sort_manifest_deps"]
 source = "vcs"
 
 [tool.coverage.run]
-source_pkgs = ["odoo_sort_manifest_depends", "tests"]
+source_pkgs = ["odoo_sort_manifest_depends"]
 branch = true
 parallel = true
 omit = [
   "src/odoo_sort_manifest_depends/__about__.py",
+  "tests/*",
 ]
 
 [tool.coverage.paths]
@@ -112,3 +113,15 @@ exclude_lines = [
   "if __name__ == .__main__.:",
   "if TYPE_CHECKING:",
 ]
+
+[tool.hatch.envs.default]
+dependencies = [
+  "pytest",
+  "pytest-cov",
+  "coverage",
+]
+
+[tool.hatch.envs.default.scripts]
+test = "pytest tests/ -v"
+test-cov = "pytest --cov=odoo_sort_manifest_depends --cov-report=term-missing tests/"
+test-cov-xml = "pytest --cov=odoo_sort_manifest_depends --cov-report=xml tests/"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+# Test requirements
+-r requirements.txt
+pytest
+pytest-cov
+coverage

--- a/src/odoo_sort_manifest_depends/sort_manifest_deps.py
+++ b/src/odoo_sort_manifest_depends/sort_manifest_deps.py
@@ -2,24 +2,32 @@
 #
 # SPDX-License-Identifier: MIT
 
+import re
 from pathlib import Path
-from re import DOTALL, sub
 
 import click
+import requests
 from click import command, option
 from diskcache import Cache
 from manifestoo_core.addon import Addon, is_addon_dir
 from manifestoo_core.core_addons import is_core_ce_addon, is_core_ee_addon
 from manifestoo_core.metadata import addon_name_to_distribution_name
 from manifestoo_core.odoo_series import OdooSeries
+from mousebender import simple
+from packaging.metadata import parse_email
+from packaging.specifiers import SpecifierSet
+from packaging.utils import parse_wheel_filename
 from platformdirs import user_cache_dir
-from requests import head
 
 NAME_DEFAULT_CATEGORY = "Default"
 OCA_ADDONS_INDEX_URL = "https://wheelhouse.odoo-community.org/oca-simple/"
 REQUEST_TIMEOUT = 2  # s
 
-other_addons_category_cache = Cache(user_cache_dir("odoo-sort-manifest-depends", "Acsone"))
+PYPI_SIMPLE_INDEX_URL = "https://pypi.org/simple/"
+PAGE_NOT_FOUND = 404
+DEFAULT_OCA_CATEGORY = "OCA"
+
+other_addons_category_cache = Cache(user_cache_dir("odoo-sort-manifest-depends", "Acsone", "1.0"))
 
 
 def _generate_depends_sections(dict_depends_by_cateogry: dict[str, list[str]]) -> str:
@@ -42,8 +50,8 @@ def _get_addons_by_name(addons_dir: Path) -> dict[str, Addon]:
     return local_addons
 
 
-def _identify_oca_addons(addon_names: list[str], odoo_series: OdooSeries) -> tuple[list[str], list[str]]:
-    oca_addons, other_addons = [], []
+def _identify_oca_addons(addon_names: list[str], odoo_series: OdooSeries) -> tuple[dict[str, list[str]], list[str]]:
+    oca_addons_by_category, other_addons = {}, []
 
     with other_addons_category_cache as cache:
         for addon_name in addon_names:
@@ -51,22 +59,77 @@ def _identify_oca_addons(addon_names: list[str], odoo_series: OdooSeries) -> tup
 
             if not category:
                 distribution_name = addon_name_to_distribution_name(addon_name, odoo_series).replace("_", "-")
-                res = head(f"{OCA_ADDONS_INDEX_URL}{distribution_name}", timeout=REQUEST_TIMEOUT)
+                res = requests.head(f"{OCA_ADDONS_INDEX_URL}{distribution_name}", timeout=REQUEST_TIMEOUT)
                 if res:
-                    category = "oca"
+                    category = get_oca_repository_name(addon_name, odoo_series) or DEFAULT_OCA_CATEGORY
                 else:
                     category = "other"
                 cache[addon_name] = category
 
-            if category == "oca":
-                oca_addons.append(addon_name)
-            else:
+            if category == "other":
                 other_addons.append(addon_name)
+            else:
+                oca_addons_by_category.setdefault(category, []).append(addon_name)
 
-    return oca_addons, other_addons
+    return oca_addons_by_category, other_addons
 
 
-def do_sorting(addons_dir: Path, odoo_version: str, project_name: str, *, oca_category: bool) -> None:
+def get_oca_repository_name(addon_name: str, odoo_series: OdooSeries) -> str | None:
+    specifier = SpecifierSet(f"=={odoo_series.value}.*")
+    distribution_name = addon_name_to_distribution_name(addon_name, odoo_series)
+    # get avaialble releases
+    project_url = simple.create_project_url(PYPI_SIMPLE_INDEX_URL, distribution_name)
+    response = requests.get(project_url, headers={"Accept": simple.ACCEPT_JSON_V1}, timeout=REQUEST_TIMEOUT)
+    if response.status_code == PAGE_NOT_FOUND:
+        # project not found
+        return None
+    response.raise_for_status()
+    content_type = response.headers["Content-Type"]
+    project_details = simple.parse_project_details(response.text, content_type, distribution_name)
+    # find the first version that matches the requested Odoo version;
+    # we assume all releases come from the same repo for a given Odoo series
+    for file in project_details["files"]:
+        if file.get("yanked"):
+            continue
+        filename = file["filename"]
+        if not filename.endswith(".whl"):
+            continue
+        _, version, _, _ = parse_wheel_filename(filename)
+        if specifier.contains(version, prereleases=True):
+            # found a release that matches the requested Odoo version
+            break
+    else:
+        # no release found that matches the requested Odoo version
+        return None
+
+    if not file.get("data-dist-info-metadata"):
+        return None
+    metadata_url = file["url"] + ".metadata"
+    response = requests.get(metadata_url, timeout=REQUEST_TIMEOUT)
+    response.raise_for_status()
+    home_page = re.search("OCA/.*", parse_email(response.text)[0].get("home_page"))
+
+    return home_page.group() if home_page else None
+
+
+def _add_oca_categories(
+    categories: dict[str, list[str]], other: list[str], odoo_series: OdooSeries, oca_category: str
+) -> tuple[dict[str, list[str]], list[str]]:
+    oca_addons_by_category, other = _identify_oca_addons(other, odoo_series)
+    if oca_category == "repository":
+        for category, oca_addons in {
+            key: sorted(value) for key, value in sorted(oca_addons_by_category.items())
+        }.items():
+            categories[category] = oca_addons
+    else:
+        # oca category == 'basic'
+        categories[DEFAULT_OCA_CATEGORY] = sorted(
+            [oca_addon for oca_addons in oca_addons_by_category.values() for oca_addon in oca_addons]
+        )
+    return categories, other
+
+
+def do_sorting(addons_dir: Path, odoo_version: str, project_name: str, *, oca_category: str) -> None:
     """
     Update manifest files to sort dependencies by type, category and then by name.
 
@@ -121,10 +184,8 @@ def do_sorting(addons_dir: Path, odoo_version: str, project_name: str, *, oca_ca
             "Odoo Enterprise": odoo_ee,
         }
 
-        # Third party
         if oca_category:
-            oca, other = _identify_oca_addons(other, odoo_series)
-            categories["OCA"] = oca
+            categories, other = _add_oca_categories(categories, other, odoo_series, oca_category)
 
         categories["Third-party"] = other
 
@@ -135,7 +196,7 @@ def do_sorting(addons_dir: Path, odoo_version: str, project_name: str, *, oca_ca
         new_depends = _generate_depends_sections(categories)
 
         pattern = r'"depends":\s*\[([^]]*)\]'
-        content = sub(pattern, new_depends, content, flags=DOTALL)
+        content = re.sub(pattern, new_depends, content, flags=re.DOTALL)
         manifest_path.write_text(content)
 
 
@@ -163,8 +224,11 @@ def do_sorting(addons_dir: Path, odoo_version: str, project_name: str, *, oca_ca
 )
 @option(
     "--oca-category",
-    is_flag=True,
-    help="Add category for third party addons coming from OCA",
+    type=click.Choice(["basic", "repository"], case_sensitive=False),
+    help="Add category for third party addons coming from OCA. "
+    "If 'basic': category is set to 'OCA'. "
+    "If 'repository': category is set as 'OCA/<repository_name>', "
+    "if the repository can not be identified, it falls into the default 'OCA' category.",
 )
 @option(
     "--reset-cache",
@@ -175,11 +239,17 @@ def sort_manifest_deps(
     local_addons_dir: str,
     odoo_version: str,
     project_name: str,
+    oca_category: str,
     *,
-    oca_category: bool = False,
     reset_cache: bool = False,
 ) -> None:
     if reset_cache:
         other_addons_category_cache.clear()
+    elif other_addons_category_cache:
+        # Remove addons from cache that have 'oca_category_repo_not_found' as category
+        with other_addons_category_cache as cache:
+            # 'oca' is for retrocompatibility with cache created in versions < v1.4
+            cache.evict(DEFAULT_OCA_CATEGORY)
+            cache.evict("oca")
 
     do_sorting(Path(local_addons_dir), odoo_version, project_name, oca_category=oca_category)

--- a/src/odoo_sort_manifest_depends/sort_manifest_deps.py
+++ b/src/odoo_sort_manifest_depends/sort_manifest_deps.py
@@ -62,9 +62,9 @@ def _identify_oca_addons(addon_names: list[str], odoo_series: OdooSeries) -> tup
                 res = requests.head(f"{OCA_ADDONS_INDEX_URL}{distribution_name}", timeout=REQUEST_TIMEOUT)
                 if res:
                     category = get_oca_repository_name(addon_name, odoo_series) or DEFAULT_OCA_CATEGORY
+                    cache[addon_name] = category
                 else:
                     category = "other"
-                cache[addon_name] = category
 
             if category == "other":
                 other_addons.append(addon_name)

--- a/src/odoo_sort_manifest_depends/sort_manifest_deps.py
+++ b/src/odoo_sort_manifest_depends/sort_manifest_deps.py
@@ -50,19 +50,21 @@ def _get_addons_by_name(addons_dir: Path) -> dict[str, Addon]:
     return local_addons
 
 
-def _identify_oca_addons(addon_names: list[str], odoo_series: OdooSeries) -> tuple[dict[str, list[str]], list[str]]:
+def _identify_oca_addons(
+    addon_names: list[str], odoo_series: OdooSeries, cache: Cache = other_addons_category_cache
+) -> tuple[dict[str, list[str]], list[str]]:
     oca_addons_by_category, other_addons = {}, []
 
-    with other_addons_category_cache as cache:
+    with cache as cache_context:
         for addon_name in addon_names:
-            category = cache.get(addon_name)
+            category = cache_context.get(addon_name)
 
             if not category:
                 distribution_name = addon_name_to_distribution_name(addon_name, odoo_series).replace("_", "-")
                 res = requests.head(f"{OCA_ADDONS_INDEX_URL}{distribution_name}", timeout=REQUEST_TIMEOUT)
                 if res:
                     category = get_oca_repository_name(addon_name, odoo_series) or DEFAULT_OCA_CATEGORY
-                    cache[addon_name] = category
+                    cache_context[addon_name] = category
                 else:
                     category = "other"
 

--- a/src/odoo_sort_manifest_depends/sort_manifest_deps.py
+++ b/src/odoo_sort_manifest_depends/sort_manifest_deps.py
@@ -63,8 +63,13 @@ def _identify_oca_addons(
                 distribution_name = addon_name_to_distribution_name(addon_name, odoo_series).replace("_", "-")
                 res = requests.head(f"{OCA_ADDONS_INDEX_URL}{distribution_name}", timeout=REQUEST_TIMEOUT)
                 if res:
-                    category = get_oca_repository_name(addon_name, odoo_series) or DEFAULT_OCA_CATEGORY
-                    cache_context[addon_name] = category
+                    category = get_oca_repository_name(addon_name, odoo_series)
+                    if category:
+                        cache_context[addon_name] = category
+                    else:
+                        # If module is found but not categories
+                        # keep it out of cache, it is probably a pending PR
+                        category = DEFAULT_OCA_CATEGORY
                 else:
                     category = "other"
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2024-present Acsone
+#
+# SPDX-License-Identifier: MIT
+
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+from diskcache import Cache
+
+from odoo_sort_manifest_depends.sort_manifest_deps import (
+    DEFAULT_OCA_CATEGORY,
+    OdooSeries,
+    _identify_oca_addons,
+)
+
+
+@pytest.fixture
+def test_cache():
+    """Create a temporary cache for testing"""
+    cache_dir = tempfile.mkdtemp()
+    cache = Cache(cache_dir)
+    yield cache
+    cache.close()
+
+
+def test_cache_oca_addon_with_repository(test_cache):
+    """Test that OCA addons with identifiable repository are cached correctly"""
+    addon_names = ["test_addon_repo"]
+    odoo_series = OdooSeries("16.0")
+
+    with (
+        patch("odoo_sort_manifest_depends.sort_manifest_deps.requests.head") as mock_head,
+        patch("odoo_sort_manifest_depends.sort_manifest_deps.get_oca_repository_name") as mock_get_repo,
+    ):
+        # Mock: addon found in OCA wheelhouse
+        mock_head.return_value = MagicMock(status_code=200)
+        # Mock: repository identified
+        mock_get_repo.return_value = "OCA/server-tools"
+
+        oca_addons, other_addons = _identify_oca_addons(addon_names, odoo_series, cache=test_cache)
+
+        # Should be categorized as OCA/server-tools
+        assert "OCA/server-tools" in oca_addons
+        assert "test_addon_repo" in oca_addons["OCA/server-tools"]
+        assert "test_addon_repo" not in other_addons
+
+        # Should be cached
+        with test_cache as cache:
+            assert cache.get("test_addon_repo") == "OCA/server-tools"
+
+
+def test_cache_oca_addon_without_repository(test_cache):
+    """Test that OCA addons without identifiable repository fall back to default OCA category"""
+    addon_names = ["test_addon_no_repo"]
+    odoo_series = OdooSeries("16.0")
+
+    with (
+        patch("odoo_sort_manifest_depends.sort_manifest_deps.requests.head") as mock_head,
+        patch("odoo_sort_manifest_depends.sort_manifest_deps.get_oca_repository_name") as mock_get_repo,
+    ):
+        # Mock: addon found in OCA wheelhouse
+        mock_head.return_value = MagicMock(status_code=200)
+        # Mock: repository NOT identified (returns None)
+        mock_get_repo.return_value = None
+
+        oca_addons, other_addons = _identify_oca_addons(addon_names, odoo_series, cache=test_cache)
+
+        # Should fall back to default OCA category
+        assert DEFAULT_OCA_CATEGORY in oca_addons
+        assert "test_addon_no_repo" in oca_addons[DEFAULT_OCA_CATEGORY]
+        assert "test_addon_no_repo" not in other_addons
+
+        # Should be cached with default OCA category
+        with test_cache as cache:
+            assert cache.get("test_addon_no_repo") == DEFAULT_OCA_CATEGORY
+
+
+def test_cache_non_oca_addon(test_cache):
+    """Test that non-OCA addons are not cached and go to other_addons"""
+    addon_names = ["test_non_oca"]
+    odoo_series = OdooSeries("16.0")
+
+    with patch("odoo_sort_manifest_depends.sort_manifest_deps.requests.head") as mock_head:
+        # Mock: addon NOT found in OCA wheelhouse
+        mock_head.return_value = None
+
+        oca_addons, other_addons = _identify_oca_addons(addon_names, odoo_series, cache=test_cache)
+
+        # Should be in other_addons
+        assert "test_non_oca" in other_addons
+        assert "test_non_oca" not in [addon for addons in oca_addons.values() for addon in addons]
+
+        # Should NOT be cached
+        with test_cache as cache:
+            assert cache.get("test_non_oca") is None
+
+
+def test_cache_reuse(test_cache):
+    """Test that cached values are reused on subsequent calls"""
+    addon_names = ["test_addon_reuse"]
+    odoo_series = OdooSeries("16.0")
+
+    with (
+        patch("odoo_sort_manifest_depends.sort_manifest_deps.requests.head") as mock_head,
+        patch("odoo_sort_manifest_depends.sort_manifest_deps.get_oca_repository_name") as mock_get_repo,
+    ):
+        # First call: addon found in OCA wheelhouse with repository
+        mock_head.return_value = MagicMock(status_code=200)
+        mock_get_repo.return_value = "OCA/server-tools"
+
+        oca_addons1, _ = _identify_oca_addons(addon_names, odoo_series, cache=test_cache)
+        assert "OCA/server-tools" in oca_addons1
+
+        # Second call: mock should not be called again (cached)
+        mock_head.reset_mock()
+        mock_get_repo.reset_mock()
+
+        oca_addons2, _ = _identify_oca_addons(addon_names, odoo_series, cache=test_cache)
+
+        # Should use cached value
+        assert "OCA/server-tools" in oca_addons2
+        mock_head.assert_not_called()
+        mock_get_repo.assert_not_called()
+
+
+def test_cache_eviction(test_cache):
+    """Test that cache entries can be evicted"""
+    addon_names = ["test_addon_evict"]
+    odoo_series = OdooSeries("16.0")
+
+    with (
+        patch("odoo_sort_manifest_depends.sort_manifest_deps.requests.head") as mock_head,
+        patch("odoo_sort_manifest_depends.sort_manifest_deps.get_oca_repository_name") as mock_get_repo,
+    ):
+        # Addon found in OCA wheelhouse but no repository identified
+        mock_head.return_value = MagicMock(status_code=200)
+        mock_get_repo.return_value = None
+
+        # First identification
+        _identify_oca_addons(addon_names, odoo_series, cache=test_cache)
+
+        # Should be cached with default OCA
+        with test_cache as cache:
+            cached_value = cache.get("test_addon_evict")
+            assert cached_value == DEFAULT_OCA_CATEGORY
+
+        # Clear the cache to test eviction behavior
+        test_cache.clear()
+
+        # Cache should be empty now
+        with test_cache as cache:
+            assert cache.get("test_addon_evict") is None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -51,7 +51,7 @@ def test_cache_oca_addon_with_repository(test_cache):
 
 
 def test_cache_oca_addon_without_repository(test_cache):
-    """Test that OCA addons without identifiable repository fall back to default OCA category"""
+    """Test that OCA addons without identifiable repository are NOT cached (pending PR case)"""
     addon_names = ["test_addon_no_repo"]
     odoo_series = OdooSeries("16.0")
 
@@ -71,9 +71,9 @@ def test_cache_oca_addon_without_repository(test_cache):
         assert "test_addon_no_repo" in oca_addons[DEFAULT_OCA_CATEGORY]
         assert "test_addon_no_repo" not in other_addons
 
-        # Should be cached with default OCA category
+        # Should NOT be cached (pending PR modules are not cached)
         with test_cache as cache:
-            assert cache.get("test_addon_no_repo") == DEFAULT_OCA_CATEGORY
+            assert cache.get("test_addon_no_repo") is None
 
 
 def test_cache_non_oca_addon(test_cache):
@@ -133,17 +133,17 @@ def test_cache_eviction(test_cache):
         patch("odoo_sort_manifest_depends.sort_manifest_deps.requests.head") as mock_head,
         patch("odoo_sort_manifest_depends.sort_manifest_deps.get_oca_repository_name") as mock_get_repo,
     ):
-        # Addon found in OCA wheelhouse but no repository identified
+        # Addon found in OCA wheelhouse WITH repository identified
         mock_head.return_value = MagicMock(status_code=200)
-        mock_get_repo.return_value = None
+        mock_get_repo.return_value = "OCA/server-tools"  # Has repository
 
         # First identification
         _identify_oca_addons(addon_names, odoo_series, cache=test_cache)
 
-        # Should be cached with default OCA
+        # Should be cached with repository category
         with test_cache as cache:
             cached_value = cache.get("test_addon_evict")
-            assert cached_value == DEFAULT_OCA_CATEGORY
+            assert cached_value == "OCA/server-tools"
 
         # Clear the cache to test eviction behavior
         test_cache.clear()


### PR DESCRIPTION
### Issue

- [x] fixes issue #14 

### Description

Instead of having every OCA addon under the category '#OCA', it sorts by github repository (e.g. #OCA/account-payment)